### PR TITLE
add modify circuit breaker status methods

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -135,6 +135,16 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 	return false
 }
 
+// SetOpen wraps `setOpen`
+func (circuit *CircuitBreaker) SetOpen() {
+	circuit.setOpen()
+}
+
+// SetClose wraps `setClose`
+func (circuit *CircuitBreaker) SetClose() {
+	circuit.setClose()
+}
+
 func (circuit *CircuitBreaker) setOpen() {
 	circuit.mutex.Lock()
 	defer circuit.mutex.Unlock()


### PR DESCRIPTION
Export CircuitBreaker `setOpen` and `setClose` method to support manually modify circuit breaker status.

New methods:

- `CircuitBreaker.SetOpen`
- `CircuitBreaker.SetClose`